### PR TITLE
Fix running scancode on a branch

### DIFF
--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -4,7 +4,7 @@ git config user.name "Automated Publisher"
 git config user.email "publish-to-github-action@users.noreply.github.com"
 
 mkdir -p ${1}
-for f in `git  diff --name-only --diff-filter=A origin/master..`; do
+for f in `git  diff --name-only --diff-filter=A origin/${GITHUB_BASE_REF}..`; do
 	echo "found new file: $f";
 	cp --parents  $f ${1};
 done


### PR DESCRIPTION
We determine the list of files using origin/master as a reference point.
However if we have a PR on a branch that isn't correct.  Change 'master'
to be ${GITHUB_BASE_REF} instead.

Signed-off-by: Kumar Gala <kumar.gala@linaro.org>