### PR TITLE
Update script for checking license on modified files as well

### DIFF
--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -4,7 +4,7 @@ git config user.name "Automated Publisher"
 git config user.email "publish-to-github-action@users.noreply.github.com"
 
 mkdir -p ${1}
-for f in `git  diff --name-only --diff-filter=A origin/${GITHUB_BASE_REF}..`; do
+for f in `git  diff --name-only --diff-filter=d origin/${GITHUB_BASE_REF}..`; do
 	echo "found new file: $f";
 	cp --parents  $f ${1};
 done


### PR DESCRIPTION
This action by default only checks files that get `added` in PR. and the rest of the files that `modified` `renamed` get ignored.
Could we enable this action by checking those `modified` or `renamed` files as well? 

@galak 