### PR TITLE
license_check.py: Do not report 'unknown-license-reference' as failures

### DIFF
--- a/license_check.py
+++ b/license_check.py
@@ -29,9 +29,16 @@ def analyze_file(config_file, scancode_file, scanned_files_dir):
     lic_main = lic_config.get("main")
     lic_cat = lic_config.get("category")
     report_missing_license = lic_config.get("report_missing", False)
+    more_cat = []
+    more_cat.append(lic_cat)
     more_lic = lic_config.get('additional', [])
     more_lic.append(lic_main)
 
+    # Scancode may report 'unknown-license-reference' if there are lines
+    # containing the word 'license' in the source files, so ignore these for
+    # now.
+    more_cat.append('Unstated License')
+    more_lic.append('unknown-license-reference')
 
     if check_copytight:
         print("Will check for missing copyrights...")
@@ -68,11 +75,11 @@ def analyze_file(config_file, scancode_file, scanned_files_dir):
                 else:
                     for lic in licenses:
                         if lic['key'] not in more_lic:
-                            report += ("* {} is not {} licensed: {}\n".format(
-                                orig_path, lic_main, lic['key']))
-                        if lic['category'] != lic_cat:
-                            report += ("* {} has non-permissive license: {}\n".format(
+                            report += ("* {} has invalid license: {}\n".format(
                                 orig_path, lic['key']))
+                        if lic['category'] not in more_cat:
+                            report += ("* {} has invalid license type: {}\n".format(
+                                orig_path, lic['category']))
                         if lic['key'] == 'unknown-spdx':
                             report += ("* {} has unknown SPDX: {}\n".format(
                                 orig_path, lic['key']))


### PR DESCRIPTION
This commit updates the license check script to ignore the reported
license type of `unknown-license-reference` because the Scancode often
reports this type when there exists a line containing the word
"license" in a source file.

Note that `unknown-license-reference` is different from finding an
unknown license type (`unknown-spdx) or entirely missing a license
header (`licenses` is empty).

For more details, refer to the issue #14.

Signed-off-by: Stephanos Ioannidis <root@stephanos.io>

Closes #14