### PR TITLE
entrypoint.sh: exit early if git fails

### DIFF
--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -1,10 +1,14 @@
 #!/bin/sh -l
 
+set -eu
+
 git config user.name "Automated Publisher"
 git config user.email "publish-to-github-action@users.noreply.github.com"
 
 mkdir -p ${1}
-for f in `git  diff --name-only --diff-filter=A origin/${GITHUB_BASE_REF}..`; do
+
+files="$( git diff --name-only --diff-filter=A origin/${GITHUB_BASE_REF}.. )"
+for f in $files; do
 	echo "found new file: $f";
 	cp --parents  $f ${1};
 done


### PR DESCRIPTION
Change the entrypoint script to configure the shell to exit on the first command error and change the git call to set a local intermediate variable, so that any failure in the git command makes the script exit early with an error code.

This way if there's some problem with the checkout the script should not fail silently.