### PR TITLE
license_check: Add support to take excluded files as input

### DIFF
--- a/.github/license_config.yml
+++ b/.github/license_config.yml
@@ -16,4 +16,8 @@ exclude:
     - cfg
   langs:
     - HTML
+  files:
+    - LICENSE
+    - NOTICE
+    - CODEOWNERS
 

--- a/.github/workflows/license_check.yml
+++ b/.github/workflows/license_check.yml
@@ -14,7 +14,7 @@ jobs:
       with:
         directory-to-scan: 'scan/'
     - name: Artifact Upload
-      uses: actions/upload-artifact@v1
+      uses: actions/upload-artifact@v4
       with:
         name: scancode
         path: ./artifacts

--- a/license_check.py
+++ b/license_check.py
@@ -19,9 +19,11 @@ def analyze_file(config_file, scancode_file, scanned_files_dir):
     if exclude:
         never_check_ext =  exclude.get("extensions", [])
         never_check_langs = exclude.get("langs", [])
+        exclude_list = exclude.get("files", [])
     else:
         never_check_ext = []
         never_check_langs = []
+        exclude_list = []
 
     copyrights = config.get("copyright", {})
     check_copytight = copyrights.get("check", False)
@@ -51,6 +53,11 @@ def analyze_file(config_file, scancode_file, scanned_files_dir):
                 continue
 
             orig_path = str(file['path']).replace(scanned_files_dir, '')
+
+            # Check if the file or directory is in the exclude list
+            if any(excluded in orig_path for excluded in exclude_list):
+                continue
+
             licenses = file['licenses']
             file_type = file.get("file_type")
             kconfig = "Kconfig" in orig_path and file_type in ['ASCII text']


### PR DESCRIPTION
For those files without the extensions, no point in running scan code as they are mostly for meta-data or CI processing.

Add an option to exclude such files.

Primarily to fix this CI failure in Zephyr https://github.com/zephyrproject-rtos/zephyr/actions/runs/12120329300/job/33833167116?pr=82424 